### PR TITLE
fixed @ CVE-2022-1243

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6450,9 +6450,9 @@ uri-js@^4.2.2:
     punycode "^2.1.0"
 
 urijs@^1.19.1:
-  version "1.19.6"
-  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.6.tgz#51f8cb17ca16faefb20b9a31ac60f84aa2b7c870"
-  integrity sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw==
+  version "1.19.11"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.11.tgz#204b0d6b605ae80bea54bea39280cdb7c9f923cc"
+  integrity sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==
 
 urix@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Descriptions :
\r, \n and \t characters in user-input URLs can potentially lead to incorrect protocol extraction when using npm package urijs prior to version 1.19.11. This can lead to XSS when the module is used to prevent passing in malicious javascript: links into HTML or Javascript (see following exploits):

```
const parse = require('urijs')
const express = require('express')
const app = express()
const port = 3000

input = "ja\r\nvascript:alert(1)"
url = parse(input)

console.log(url)

app.get('/', (req, res) => {
 if (url.protocol !== "javascript:") {res.send("<iframe src=\'" + input + "\'>CLICK ME!</iframe>")}
})

app.listen(port, () => {
 console.log(`Example app listening on port ${port}`)
})
```

**CVE-2022-1243**
`CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N`
GHSA-3vjf-82ff-p4r3
